### PR TITLE
Add ci job to build cyber from any branch to rebyc-build brunch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,9 +8,10 @@ workflows:
           filters:
             branches:
               only: episode-1
-
-
+      - build_and_deploy_rebyc
+      
 jobs:
+
   update_distribution_app:
     working_directory: ~/workdir
     docker:
@@ -36,3 +37,29 @@ jobs:
             git add --all
             git commit -m "Circle CI: Update Site [skip ci]"
             git push -q -f https://${DOCS_GITHUB_TOKEN}@github.com/cybercongress/dot-cyber.git master:gh-pages
+
+  build_and_deploy_rebyc:
+    working_directory: ~/workdir
+    docker:
+      - image: circleci/node:12.14.0-browsers
+    steps:
+      - checkout
+      - run:
+          name: Update app
+          command: |
+            git clone -q --depth 1 https://${DOCS_GITHUB_TOKEN}@github.com/cybercongress/dot-cyber.git
+      - deploy:
+          name: Build app from commited branch
+          working_directory: ~/workdir
+          command: |
+            rm -rf build/
+            yarn install
+            yarn build
+            cd build
+            git init
+            echo "rebyc.cyber.page" > CNAME
+            git config user.email "cybercongress42@gmail.com"
+            git config user.name "Cyber Admin"
+            git add --all
+            git commit -m "Circle CI: update rebyc build [skip ci]"
+            git push -q -f https://${DOCS_GITHUB_TOKEN}@github.com/cybercongress/dot-cyber.git master:rebyc-build


### PR DESCRIPTION
The CI will build cyber from any commit of every branch and push it to `rebyc-build` branch for autodeploy to rebyc.cyber.page