### PR TITLE
fix(components): crashing tooltips

### DIFF
--- a/src/components/SearchItem/status.jsx
+++ b/src/components/SearchItem/status.jsx
@@ -63,10 +63,7 @@ function Status({ status }) {
 
   return (
     <div>
-      <Tooltip
-        placement="bottom"
-        tooltip={<div style={{ padding: 18 }}>{text}</div>}
-      >
+      <Tooltip placement="bottom" tooltip={text}>
         <div
           className={cx(styles.customPill, {
             [styles.glow]: status === 'understandingState',

--- a/src/components/ToggleMenu/menuButton.jsx
+++ b/src/components/ToggleMenu/menuButton.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
-import { Pane, Text, Tooltip } from '@cybercongress/gravity';
-// import { Tooltip } from '..';
+import { Pane } from '@cybercongress/gravity';
 import { Link } from 'react-router-dom';
 
 const stausImgCyb = require('../../image/cyb.svg');

--- a/src/components/tooltip/styles.scss
+++ b/src/components/tooltip/styles.scss
@@ -5,6 +5,7 @@
   white-space: normal;
   box-shadow: 0px 0px 4px 1px #38d6ae;
   z-index: 4;
+  padding: 10px 12px;
 
   &BorderNone {
     box-shadow: none;

--- a/src/components/ui/noItems.jsx
+++ b/src/components/ui/noItems.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Pane, Text, Tooltip } from '@cybercongress/gravity';
+import { Pane, Text } from '@cybercongress/gravity';
 
 const noitem = require('../../image/noitem.svg');
 

--- a/src/containers/Validators/components/InfoBalance.jsx
+++ b/src/containers/Validators/components/InfoBalance.jsx
@@ -8,7 +8,7 @@ import { CYBER } from '../../../utils/config';
 const { DENOM_CYBER, HYDROGEN } = CYBER;
 
 const TootipContent = () => (
-  <div style={{ padding: '10px', width: 200 }}>
+  <div style={{ width: 200 }}>
     you receive H form staked BOOT, you can use H for investmint A and V
   </div>
 );

--- a/src/containers/Validators/components/table.jsx
+++ b/src/containers/Validators/components/table.jsx
@@ -49,7 +49,7 @@ function TableHeroes({ mobile, showJailed, children }) {
                 <Tooltip
                   placement="bottom"
                   tooltip={
-                    <div style={{ width: 150, padding: 10 }}>
+                    <div style={{ width: 150 }}>
                       Amount of {CYBER.DENOM_CYBER.toUpperCase()} (tokens you
                       bonded to validator in)
                     </div>

--- a/src/containers/Validators/components/tableItem.jsx
+++ b/src/containers/Validators/components/tableItem.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { TableEv as Table, Tooltip } from '@cybercongress/gravity';
+import { TableEv as Table } from '@cybercongress/gravity';
 import { Link } from 'react-router-dom';
 import { formatNumber, formatCurrency } from '../../../utils/utils';
 import { FormatNumber, Dots, NumberCurrency } from '../../../components';

--- a/src/containers/Wallet/Wallet.jsx
+++ b/src/containers/Wallet/Wallet.jsx
@@ -1,7 +1,7 @@
 /* eslint-disable no-nested-ternary */
 import React from 'react';
 import { connect } from 'react-redux';
-import { Pane, Text, Tooltip, Icon } from '@cybercongress/gravity';
+import { Pane, Text, Icon } from '@cybercongress/gravity';
 import Web3Utils from 'web3-utils';
 import { Link } from 'react-router-dom';
 

--- a/src/containers/account/component/tableLink.jsx
+++ b/src/containers/account/component/tableLink.jsx
@@ -1,15 +1,9 @@
 import React, { useState, useEffect, useMemo, useCallback } from 'react';
-import {
-  Pane,
-  Text,
-  TableEv as Table,
-  Tooltip,
-  Icon,
-} from '@cybercongress/gravity';
+import { Pane, Text, TableEv as Table, Icon } from '@cybercongress/gravity';
 import { Link } from 'react-router-dom';
 import InfiniteScroll from 'react-infinite-scroll-component';
 import { trimString, formatNumber } from '../../../utils/utils';
-import { NoItems, Cid, Dots, TextTable } from '../../../components';
+import { NoItems, Cid, Dots, TextTable, Tooltip } from '../../../components';
 
 const dateFormat = require('dateformat');
 
@@ -22,9 +16,10 @@ const TableLink = ({ data }) => {
     }, 250);
   }, [itemsToShow, setItemsToShow]);
 
-  const displayedPalettes = useMemo(() => data.slice(0, itemsToShow), [
-    itemsToShow,
-  ]);
+  const displayedPalettes = useMemo(
+    () => data.slice(0, itemsToShow),
+    [itemsToShow]
+  );
 
   const validatorRows = displayedPalettes.map((item, i) => (
     <Table.Row
@@ -74,12 +69,7 @@ const TableLink = ({ data }) => {
             <TextTable>tx</TextTable>
           </Table.TextHeaderCell>
           <Table.TextHeaderCell flex={1.5} textAlign="center">
-            <TextTable>
-              timestamp{' '}
-              <Tooltip content="UTC" position="bottom">
-                <Icon icon="info-sign" color="#3ab793d4" marginLeft={5} />
-              </Tooltip>
-            </TextTable>
+            <TextTable>timestamp, UTC</TextTable>
           </Table.TextHeaderCell>
           <Table.TextHeaderCell textAlign="center">
             <TextTable>from</TextTable>

--- a/src/containers/application/leftTooltip.jsx
+++ b/src/containers/application/leftTooltip.jsx
@@ -11,7 +11,7 @@ function LeftTooltip({ block }) {
     <Tooltip
       placement="bottom"
       tooltip={
-        <span style={{ width: '225px', display: 'block', padding: 10 }}>
+        <span style={{ width: '225px', display: 'block' }}>
           You are on the{' '}
           <a
             target="_blank"

--- a/src/containers/blok/index.jsx
+++ b/src/containers/blok/index.jsx
@@ -2,13 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { connect } from 'react-redux';
 import gql from 'graphql-tag';
 import { useSubscription } from '@apollo/react-hooks';
-import {
-  Pane,
-  Text,
-  TableEv as Table,
-  Icon,
-  Tooltip,
-} from '@cybercongress/gravity';
+import { Pane, Text, TableEv as Table, Icon } from '@cybercongress/gravity';
 import { Link } from 'react-router-dom';
 import InfiniteScroll from 'react-infinite-scroll-component';
 import { getGraphQLQuery } from '../../utils/search/utils';
@@ -141,12 +135,7 @@ const Block = ({ blockThis }) => {
             <TextTable>proposer address</TextTable>
           </Table.TextHeaderCell>
           <Table.TextHeaderCell textAlign="center">
-            <TextTable>
-              timestamp{' '}
-              <Tooltip content="UTC" position="bottom">
-                <Icon icon="info-sign" color="#3ab793d4" marginLeft={5} />
-              </Tooltip>
-            </TextTable>
+            <TextTable>timestamp, UTC</TextTable>
           </Table.TextHeaderCell>
         </Table.Head>
         <Table.Body

--- a/src/containers/txs/index.jsx
+++ b/src/containers/txs/index.jsx
@@ -2,13 +2,7 @@ import React, { useEffect, useStatea } from 'react';
 import gql from 'graphql-tag';
 import { v4 as uuidv4 } from 'uuid';
 import { useSubscription } from '@apollo/react-hooks';
-import {
-  Pane,
-  Text,
-  TableEv as Table,
-  Icon,
-  Tooltip,
-} from '@cybercongress/gravity';
+import { Pane, Text, TableEv as Table, Icon } from '@cybercongress/gravity';
 import { Link } from 'react-router-dom';
 import { getGraphQLQuery } from '../../utils/search/utils';
 import { trimString, formatNumber, formatCurrency } from '../../utils/utils';
@@ -114,12 +108,7 @@ const Txs = () => {
             <TextTable>tx</TextTable>
           </Table.TextHeaderCell>
           <Table.TextHeaderCell flex={1.3} textAlign="center">
-            <TextTable>
-              timestamp{' '}
-              <Tooltip content="UTC" position="bottom">
-                <Icon icon="info-sign" color="#3ab793d4" marginLeft={5} />
-              </Tooltip>
-            </TextTable>
+            <TextTable>timestamp, UTC</TextTable>
           </Table.TextHeaderCell>
           <Table.TextHeaderCell textAlign="center">
             <TextTable>type</TextTable>

--- a/src/containers/validator/fans.jsx
+++ b/src/containers/validator/fans.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useRef, useMemo, useCallback } from 'react';
-import { Pane, Tooltip, Text, TableEv as Table } from '@cybercongress/gravity';
+import { Pane, Text, TableEv as Table } from '@cybercongress/gravity';
 import InfiniteScroll from 'react-infinite-scroller';
 import {
   CardTemplate,


### PR DESCRIPTION
- replace `Tooltip` from `@cybercongress/gravity` to `Tooltip` component, or to text (**crashed page**)
- add padding
- fix overlaying

<img width="288" alt="Screenshot 2023-03-22 at 21 14 34" src="https://user-images.githubusercontent.com/18665326/226985006-26b45ce0-bbef-43c5-8dab-48bbecc86bfc.png">
<img width="236" alt="Screenshot 2023-03-22 at 20 00 59" src="https://user-images.githubusercontent.com/18665326/226984985-0b08c060-b3ce-4baa-808e-1ebcc5d0efc6.png">

<hr/>

<img width="332" alt="Screenshot 2023-03-22 at 21 13 32" src="https://user-images.githubusercontent.com/18665326/226985444-333ae190-7423-4816-897c-efa9ca2715ec.png">
<img width="341" alt="Screenshot 2023-03-22 at 20 00 37" src="https://user-images.githubusercontent.com/18665326/226984784-530200ea-8d76-45da-9dff-5865e5632fcd.png">


Fixes:
https://github.com/cybercongress/cyb/issues/750
https://github.com/cybercongress/cyb/issues/797