### PR TITLE
feat(stores): followings passports

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -104,6 +104,15 @@
         ]
       }
     ],
+    "no-restricted-imports": "off",
+    "@typescript-eslint/no-restricted-imports": [
+      "warn",
+      {
+        "name": "react-redux",
+        "importNames": ["useSelector", "useDispatch"],
+        "message": "Use typed hooks `useAppDispatch` and `useAppSelector` instead."
+      }
+    ],
     "react/jsx-filename-extension": "off",
     "react/tsx-filename-extension": "off",
     "import/no-unused-modules": [1],

--- a/src/components/account/account.tsx
+++ b/src/components/account/account.tsx
@@ -8,7 +8,7 @@ import { activePassport } from '../../containers/portal/utils';
 import { AvataImgIpfs } from '../../containers/portal/components/avataIpfs';
 import { routes } from 'src/routes';
 import { useGetPassportByAddress } from 'src/containers/sigma/hooks';
-import usePassportByAddress from 'src/features/passport/hooks';
+import usePassportByAddress from 'src/features/passport/hooks/usePassportByAddress';
 
 function useGetValidatorInfo(address: string) {
   const queryClient = useQueryClient();

--- a/src/components/actionBar/index.tsx
+++ b/src/components/actionBar/index.tsx
@@ -9,7 +9,7 @@ import { Networks } from 'src/types/networks';
 import ButtonIcon from '../buttons/ButtonIcon';
 import styles from './styles.scss';
 import Button from '../btnGrd';
-import usePassportByAddress from 'src/features/passport/hooks';
+import usePassportByAddress from 'src/features/passport/hooks/usePassportByAddress';
 
 const back = require('../../image/arrow-left-img.svg');
 

--- a/src/containers/application/Header/SwitchAccount/SwitchAccount.tsx
+++ b/src/containers/application/Header/SwitchAccount/SwitchAccount.tsx
@@ -4,20 +4,19 @@ import { Link } from 'react-router-dom';
 import { usePopperTooltip } from 'react-popper-tooltip';
 import { Transition } from 'react-transition-group';
 import { useIpfs } from 'src/contexts/ipfs';
-import { useDispatch, useSelector } from 'react-redux';
-import { RootState } from 'src/redux/store';
 
 import useOnClickOutside from 'src/hooks/useOnClickOutside';
 import { routes } from 'src/routes';
+import usePassportByAddress from 'src/features/passport/hooks/usePassportByAddress';
+
+import { useAppDispatch, useAppSelector } from 'src/redux/hooks';
 import { AvataImgIpfs } from '../../../portal/components/avataIpfs';
-import useGetPassportByAddress from '../../../sigma/hooks/useGetPassportByAddress';
 import styles from './SwitchAccount.module.scss';
 import networkStyles from '../SwitchNetwork/SwitchNetwork.module.scss';
 import useMediaQuery from '../../../../hooks/useMediaQuery';
 import robot from '../../../../image/temple/robot.png';
 import Karma from '../../Karma/Karma';
 import { setDefaultAccount } from '../../../../redux/features/pocket';
-import usePassportByAddress from 'src/features/passport/hooks';
 
 // should be refactored
 function AccountItem({
@@ -87,15 +86,11 @@ function AccountItem({
 function SwitchAccount() {
   const { node, isReady: ipfsStatus } = useIpfs();
   const mediaQuery = useMediaQuery('(min-width: 768px)');
+
   const [controlledVisible, setControlledVisible] = React.useState(false);
 
-  const {
-    pocket: { defaultAccount, accounts },
-  } = useSelector((state: RootState) => {
-    return {
-      pocket: state.pocket,
-    };
-  });
+  const { defaultAccount, accounts } = useAppSelector((state) => state.pocket);
+  const dispatch = useAppDispatch();
 
   const useGetAddress = defaultAccount?.account?.cyber?.bech32 || null;
 
@@ -108,8 +103,6 @@ function SwitchAccount() {
     onVisibleChange: setControlledVisible,
     placement: 'bottom',
   });
-
-  const dispatch = useDispatch();
 
   const containerRef = useRef<HTMLDivElement>(null);
 

--- a/src/containers/sigma/index.tsx
+++ b/src/containers/sigma/index.tsx
@@ -14,7 +14,7 @@ import { ContainerGradientText } from '../../components';
 import ActionBarPortalGift from '../portal/gift/ActionBarPortalGift';
 import STEP_INFO from '../portal/gift/utils';
 import styles from './Sigma.module.scss';
-import usePassportByAddress from 'src/features/passport/hooks';
+import usePassportByAddress from 'src/features/passport/hooks/usePassportByAddress';
 
 const valueContext = {
   totalCap: 0,

--- a/src/features/passport/hooks/useFollowingsPassports.ts
+++ b/src/features/passport/hooks/useFollowingsPassports.ts
@@ -1,0 +1,28 @@
+import { useEffect } from 'react';
+import { useQueryClient } from 'src/contexts/queryClient';
+import { selectFollowings } from 'src/redux/features/currentAccount';
+import { useAppDispatch, useAppSelector } from 'src/redux/hooks';
+import {
+  getFollowingsPassports,
+  selectFollowingsPassports,
+} from '../passports.redux';
+
+function useFollowingsPassports() {
+  const queryClient = useQueryClient();
+
+  const followings = useAppSelector(selectFollowings);
+  const followingsPassports = useAppSelector(selectFollowingsPassports);
+  const dispatch = useAppDispatch();
+
+  useEffect(() => {
+    if (!queryClient) {
+      return;
+    }
+
+    dispatch(getFollowingsPassports(queryClient));
+  }, [queryClient, dispatch, followings]);
+
+  return followingsPassports;
+}
+
+export default useFollowingsPassports;

--- a/src/features/passport/hooks/usePassportByAddress.ts
+++ b/src/features/passport/hooks/usePassportByAddress.ts
@@ -1,9 +1,8 @@
 import { useEffect } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
-import { RootState } from 'src/redux/store';
 import { useQueryClient } from 'src/contexts/queryClient';
-import { getPassport } from './passports.redux';
 import { PATTERN_CYBER } from 'src/utils/config';
+import { useAppDispatch, useAppSelector } from 'src/redux/hooks';
+import { getPassport } from '../passports.redux';
 
 type Props = {
   address: string | null;
@@ -11,9 +10,10 @@ type Props = {
 
 // add 'refresh' prop
 function usePassportByAddress(address: Props['address']) {
-  const passports = useSelector((state: RootState) => state.passports);
   const queryClient = useQueryClient();
-  const dispatch = useDispatch();
+
+  const passports = useAppSelector((state) => state.passports);
+  const dispatch = useAppDispatch();
 
   useEffect(() => {
     if (!queryClient || !address) {

--- a/src/redux/features/currentAccount.ts
+++ b/src/redux/features/currentAccount.ts
@@ -1,4 +1,5 @@
 import { PayloadAction, createSlice } from '@reduxjs/toolkit';
+import { RootState } from '../store';
 
 type SliceState = {
   community: {
@@ -29,6 +30,9 @@ const slice = createSlice({
     },
   },
 });
+
+export const selectFollowings = (state: RootState) =>
+  state.currentAccount.community.following;
 
 export const { setCommunity } = slice.actions;
 

--- a/src/redux/hooks.ts
+++ b/src/redux/hooks.ts
@@ -1,0 +1,7 @@
+import { TypedUseSelectorHook, useDispatch, useSelector } from 'react-redux';
+import type { RootState, AppDispatch } from './store';
+
+// Use throughout your app instead of plain `useDispatch` and `useSelector`
+type DispatchFunc = () => AppDispatch;
+export const useAppDispatch: DispatchFunc = useDispatch;
+export const useAppSelector: TypedUseSelectorHook<RootState> = useSelector;

--- a/src/redux/types.d.ts
+++ b/src/redux/types.d.ts
@@ -1,0 +1,10 @@
+import { ThunkAction } from 'redux-thunk';
+import { RootState } from './store';
+import { AnyAction, UnknownAction } from 'redux';
+
+export type AppThunk<ReturnType = void> = ThunkAction<
+  ReturnType,
+  RootState,
+  unknown,
+  AnyAction
+>;


### PR DESCRIPTION
- added `useFollowingsPassport` hook to get followings passports

- use `useAppSelector` and `useAppDispatch` (with types) now, instead of `useSelector`, `useDispatch`
