### PR TITLE
fix(appmenu): adaptive circular menu change

### DIFF
--- a/src/components/appMenu/CircularMenu.module.scss
+++ b/src/components/appMenu/CircularMenu.module.scss
@@ -10,7 +10,7 @@
 
 .menu {
   --diameter: 140px;
-  --i: 22deg; //elements angle
+  --i: 23deg; //elements angle
   --delta: 0deg; //second menu layer angle
   list-style-type: none;
   padding: 0;
@@ -51,4 +51,3 @@
 .menu li:nth-child(7) {
   --r: calc(1 * var(--i));
 }
-

--- a/src/components/appMenu/CircularMenu.tsx
+++ b/src/components/appMenu/CircularMenu.tsx
@@ -10,8 +10,7 @@ declare module 'react' {
   interface CSSProperties {
     '--diameter'?: string;
     '--delta'?: string;
-    '--icon-size'?: string;
-    '--button-size'?: string;
+    '--i'?: string;
   }
 }
 
@@ -21,13 +20,11 @@ function CircularMenu({ circleSize }) {
   const linkChunks = _.chunk(itemsMenu(), chunkSize);
   const location = useLocation();
 
-  const buttonSize = Math.min(circleSize * 0.15, 38);
-  const iconSize = buttonSize - 8;
-
   const calculateDiameter = (index, circleSize) => {
-    const menuCircleDiameter = circleSize / 2 + 40 * (index + 1) - 10;
-    const nextLevelMenuAngle = index === 1 ? 11 : 0;
-    return { menuCircleDiameter, nextLevelMenuAngle };
+    const menuCircleDiameter = circleSize / 2 + 45 * (index + 1) - 10;
+    const nextLevelMenuAngle = index === 1 ? -28 : 0; // decreases the angle of second menu layer
+    const menuItemsAngle = index === 1 ? 16 : 23; // angle in wich menu items spreads around brain
+    return { menuCircleDiameter, nextLevelMenuAngle, menuItemsAngle };
   };
 
   const isActiveItem = (item: MenuItem) => {
@@ -58,10 +55,8 @@ function CircularMenu({ circleSize }) {
   return (
     <div>
       {linkChunks.map((chunk, index) => {
-        const { menuCircleDiameter, nextLevelMenuAngle } = calculateDiameter(
-          index,
-          circleSize
-        );
+        const { menuCircleDiameter, nextLevelMenuAngle, menuItemsAngle } =
+          calculateDiameter(index, circleSize);
         return (
           <div
             key={index}
@@ -73,8 +68,7 @@ function CircularMenu({ circleSize }) {
               style={{
                 '--diameter': `${menuCircleDiameter}px`,
                 '--delta': `${nextLevelMenuAngle}deg`,
-                '--icon-size': `${iconSize}px`,
-                '--button-size': `${buttonSize}px`,
+                '--i': `${menuItemsAngle}deg`,
               }}
             >
               {chunk.map((item, index) => {

--- a/src/components/appMenu/CircularMenuItem.module.scss
+++ b/src/components/appMenu/CircularMenuItem.module.scss
@@ -5,8 +5,8 @@
   opacity: 1;
   background-color: #101010;
   border-radius: 50%;
-  width: var(--button-size, 38px);
-  height: var(--button-size, 38px);
+  width: 38px;
+  height: 38px;
   justify-content: center;
   align-items: center;
   display: flex;
@@ -30,8 +30,8 @@
 }
 
 .icon {
-  width: var(--icon-size, 30px);
-  height: var(--icon-size, 30px);
+  width: 30px;
+  height: 30px;
   object-fit: fill;
   border-radius: 50%;
   justify-content: center;
@@ -42,8 +42,7 @@
 .external {
   display: block;
   position: absolute;
-  bottom: 0;
-  right: 0;
+  bottom: 5px;
   transform: translate(50%, 50%);
   width: 20px;
   height: 20px;

--- a/src/components/appMenu/MobileMenu.tsx
+++ b/src/components/appMenu/MobileMenu.tsx
@@ -1,14 +1,15 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { useLocation, NavLink } from 'react-router-dom';
 import itemsMenu from 'src/utils/appsMenu';
 import styles from './MobileMenu.module.scss';
 import { MenuItem } from 'src/types/menu';
 import cx from 'classnames';
-
+import useOnClickOutside from 'src/hooks/useOnClickOutside';
 const MobileMenu = () => {
   const [isOpen, setIsOpen] = useState(false);
   const [activeItem, setActiveItem] = useState<MenuItem | null>(null);
   const location = useLocation();
+  const menuRef = useRef<HTMLDivElement>(null);
 
   const toggleMenu = () => setIsOpen(!isOpen);
 
@@ -33,8 +34,11 @@ const MobileMenu = () => {
     setActiveItem(activeMenuItem || null);
   }, [location]);
 
+  useOnClickOutside(menuRef, () => setIsOpen(false));
+
   return (
     <div
+      ref={menuRef}
       className={cx(styles.mobileMenu, {
         [styles.open]: isOpen,
         [styles.closed]: !isOpen,
@@ -50,7 +54,7 @@ const MobileMenu = () => {
           className={cx(styles.menuButton, { [styles.active]: isOpen })}
           onClick={toggleMenu}
         >
-          <img src={activeItem?.icon} className={styles.icon} />
+          <img src={activeItem?.icon} className={styles.icon} alt="menu icon" />
         </button>
         {itemsMenu().map((item, index) => {
           const isExternal = item.to.startsWith('http');
@@ -66,7 +70,11 @@ const MobileMenu = () => {
                   rel: 'noreferrer noopener',
                 })}
               >
-                <img src={item.icon} className={styles.icon} alt="img" />
+                <img
+                  src={item.icon}
+                  className={styles.icon}
+                  alt="menu item icon"
+                />
                 {isExternal && <span className={styles.external}></span>}
               </NavLink>
             )


### PR DESCRIPTION
1. Now icons dont scale and keeping their size, also add degree variable to compress second level of menu.
2. Add OnClickOutside hook so u can close mobile menu by tapping anywhere on screen.