### PR TITLE
docs(contracts): update cw-cybergift repo references to merged cw-cyber

### DIFF
--- a/src/services/soft.js/api/passport.ts
+++ b/src/services/soft.js/api/passport.ts
@@ -4,7 +4,7 @@ import { CyberClient } from '@cybercongress/cyber-js';
 // import { CONTRACT_ADDRESS_PASSPORT } from 'src/containers/portal/utils';
 import { getPassport } from 'src/services/passports/lcd.ts';
 
-// https://github.com/cybercongress/cw-cybergift/tree/main/contracts/cw-cyber-passport/schema
+// https://github.com/cyberia-to/cw-cyber/tree/main/contracts/cw-cyber-passport/schema
 export type PassportContractQuery =
   | {
       active_passport: {

--- a/src/types/citizenship.d.ts
+++ b/src/types/citizenship.d.ts
@@ -5,7 +5,7 @@ export type Citizenship = {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   approvals: any[];
   token_uri: string | null;
-  // https://github.com/cybercongress/cw-cybergift/blob/main/contracts/cw-cyber-passport/schema/passport_metadata.json
+  // https://github.com/cyberia-to/cw-cyber/blob/main/contracts/cw-cyber-passport/schema/passport_metadata.json
   extension: {
     avatar: string;
     nickname: string;


### PR DESCRIPTION
## Summary
- Updated documentation comments that referenced the old `cw-cybergift` repository
- Now pointing to the merged location in `cw-cyber` repository

## Changed Files
- `src/types/citizenship.d.ts` - Updated schema reference URL
- `src/services/soft.js/api/passport.ts` - Updated schema reference URL

## Blocked By
This PR depends on the merge of cw-cybergift into cw-cyber:
- https://github.com/cyberia-to/cw-cyber/pull/45

## Test plan
- [x] Documentation links only - no functional changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)