### PR TITLE
fix: swap precision, fee rate, max order ratio (#663)

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,3 +1,10 @@
+[build]
+  command = "deno install && deno task build"
+  publish = "build"
+
+[build.environment]
+  NODE_VERSION = "20"
+  DENO_VERSION = "v2.1.4"
+
 [[plugins]]
   package = "./netlify/prebuild/"
-  

--- a/src/pages/teleport/swap/actionBar.swap.tsx
+++ b/src/pages/teleport/swap/actionBar.swap.tsx
@@ -14,8 +14,6 @@ import { RootState } from 'src/redux/store';
 import { Option } from 'src/types';
 import { Account, ActionBar as ActionBarCenter } from '../../../components';
 import { LEDGER } from '../../../utils/config';
-import { convertAmount, convertAmountReverce } from '../../../utils/utils';
-
 import ActionBarPingTxs from '../components/actionBarPingTxs';
 import { sortReserveCoinDenoms } from './utils';
 
@@ -23,8 +21,8 @@ const POOL_TYPE_INDEX = 1;
 
 const { STAGE_INIT, STAGE_ERROR, STAGE_SUBMITTED } = LEDGER;
 
-const coinFunc = (amount: number, denom: string): Coin => {
-  return { denom, amount: new BigNumber(amount).toString(10) };
+const coinFunc = (amount: BigNumber | string | number, denom: string): Coin => {
+  return { denom, amount: new BigNumber(amount).toFixed(0) };
 };
 
 type Props = {
@@ -67,11 +65,15 @@ function ActionBar({ stateActionBar }: { stateActionBar: Props }) {
 
       const [{ coinDecimals: coinDecimalsA }] = tracesDenom(tokenA);
 
-      const amountTokenA = convertAmountReverce(tokenAAmount, coinDecimalsA);
+      const amountTokenA = new BigNumber(tokenAAmount)
+        .shiftedBy(coinDecimalsA)
+        .dp(0, BigNumber.ROUND_FLOOR);
 
       setStage(STAGE_SUBMITTED);
+
+      const swapFeeRate = new BigNumber(params.swapFeeRate).shiftedBy(-18);
       const offerCoinFee = coinFunc(
-        Math.ceil(amountTokenA * convertAmount(parseFloat(params.swapFeeRate), 18) * 0.5),
+        amountTokenA.multipliedBy(swapFeeRate).multipliedBy(0.5).dp(0, BigNumber.ROUND_CEIL),
         tokenA
       );
 

--- a/src/pages/teleport/swap/components/TokenSetterSwap.tsx
+++ b/src/pages/teleport/swap/components/TokenSetterSwap.tsx
@@ -73,7 +73,7 @@ function TokenSetterSwap({
         <InputNumberDecimalScale
           id={id}
           value={tokenAmountValue}
-          onValueChange={(value, e) => amountChangeHandler(value, e.target.id)}
+          onValueChange={(value) => amountChangeHandler(value, id)}
           title={`choose amount to ${textAction}`}
           validAmount={validInputAmount}
           validAmountMessage={validAmountMessage}

--- a/src/pages/teleport/swap/swap.tsx
+++ b/src/pages/teleport/swap/swap.tsx
@@ -192,19 +192,28 @@ function Swap() {
     return 0;
   }, [poolPrice, swapPrice]);
 
+  const exceedsMaxOrderRatio = useMemo(() => {
+    if (!tokenAPoolAmount || !tokenAAmount || !tokenACoinDecimals) {
+      return false;
+    }
+    const rawAmount = new BigNumber(tokenAAmount).shiftedBy(tokenACoinDecimals);
+    const maxOrderable = new BigNumber(tokenAPoolAmount).multipliedBy(0.1);
+    return rawAmount.isGreaterThan(maxOrderable);
+  }, [tokenAAmount, tokenAPoolAmount, tokenACoinDecimals]);
+
   useEffect(() => {
     // validation swap
     let exceeded = true;
 
     const validTokenAmountA = !validInputAmountTokenA && Number(tokenAAmount) > 0;
 
-    // check pool , check slippage 3%
-    if (poolPrice !== 0 && validTokenAmountA && useGetSlippage < 3) {
+    // check pool, check slippage 3%, check max order ratio 10%
+    if (poolPrice !== 0 && validTokenAmountA && useGetSlippage < 3 && !exceedsMaxOrderRatio) {
       exceeded = false;
     }
 
     setIsExceeded(exceeded);
-  }, [poolPrice, tokenAAmount, validInputAmountTokenA, useGetSlippage]);
+  }, [poolPrice, tokenAAmount, validInputAmountTokenA, useGetSlippage, exceedsMaxOrderRatio]);
 
   const pairPrice = useMemo(() => {
     const isValid = poolPrice && tokenA && tokenB;

--- a/src/pages/teleport/swap/utils.ts
+++ b/src/pages/teleport/swap/utils.ts
@@ -18,8 +18,8 @@ export function calculatePairAmount(inputAmount: string | number, state) {
   let counterPairAmount = new BigNumber(0);
   let swapPrice = new BigNumber(0);
   let price = new BigNumber(0);
-  const feeRatio = new BigNumber(0.03);
-  const swapFeeRatio = new BigNumber(1).minus(feeRatio); // TO DO get params
+  const feeRatio = new BigNumber(0.003);
+  const swapFeeRatio = new BigNumber(1).minus(feeRatio);
 
   const poolAmountA = new BigNumber(tokenAPoolAmount);
   const poolAmountB = new BigNumber(tokenBPoolAmount);


### PR DESCRIPTION
## Summary
- Replace floating-point `Math.ceil` with BigNumber chain for offerCoinFee calculation (precision loss on large amounts)
- Fix swap fee rate from 3% to 0.3% matching chain `SwapFeeRate` param
- Add MaxOrderAmountRatio (10%) validation — blocks swap button when offer exceeds 10% of pool reserves
- Fix TokenSetterSwap `onValueChange` crash on prop-driven re-renders

## Test plan
- [ ] Swap 100 BOOT → H: output should be ~704 H (0.3% fee), not ~683 H (old 3% fee)
- [ ] Enter amount > 10% of pool reserves: Swap button should be disabled
- [ ] Enter very large number (e.g. 100T): no crash, slippage shows correctly, button disabled
- [ ] Normal small swap executes successfully with wallet connected

🤖 Generated with [Claude Code](https://claude.com/claude-code)