### PR TITLE
fix: swap UI improvements (min amount, tx timeout, fee, countdown)

### DIFF
--- a/src/features/adviser/useAdviserTexts.tsx
+++ b/src/features/adviser/useAdviserTexts.tsx
@@ -1,5 +1,4 @@
 import { useCallback, useEffect, useState } from 'react';
-import { Link } from 'react-router-dom';
 import { Dots } from 'src/components';
 import { Props as AdviserProps } from 'src/features/adviser/Adviser/Adviser';
 import { useSetAdviser } from 'src/features/adviser/context';
@@ -48,7 +47,7 @@ function useAdviserTexts(
     if (error && !messageShowed) {
       adviserText = (
         <p>
-          {error} {txHash && <Link to={routes.txExplorer.getLink(txHash)}>check tx</Link>}
+          {error} {txHash && <a href={routes.txExplorer.getLink(txHash)}>check tx</a>}
         </p>
       );
       color = 'red';

--- a/src/pages/teleport/components/actionBarPingTxs.tsx
+++ b/src/pages/teleport/components/actionBarPingTxs.tsx
@@ -22,25 +22,39 @@ function ActionBarPingTxs({ stageActionBarStaps }) {
     stageActionBarStaps;
 
   useEffect(() => {
+    let retries = 0;
+    const MAX_RETRIES = 20;
+
     const confirmTx = async () => {
       if (queryClient && txHash) {
         setStage(STAGE_CONFIRMING);
-        const response = await queryClient.getTx(txHash);
-        if (response !== null) {
-          if (response.code === 0) {
-            setStage(STAGE_CONFIRMED);
-            setTxHeight(response.height);
-            if (updateFunc) {
-              updateFunc();
+        try {
+          const response = await queryClient.getTx(txHash);
+          if (response !== null) {
+            if (response.code === 0) {
+              setStage(STAGE_CONFIRMED);
+              setTxHeight(response.height);
+              if (updateFunc) {
+                updateFunc();
+              }
+              return;
             }
-            return;
+            if (response.code) {
+              setStage(STAGE_ERROR);
+              setTxHeight(response.height);
+              setErrorMessage(response.rawLog);
+              return;
+            }
           }
-          if (response.code) {
-            setStage(STAGE_ERROR);
-            setTxHeight(response.height);
-            setErrorMessage(response.rawLog);
-            return;
-          }
+        } catch (error) {
+          console.error('getTx error:', error);
+        }
+
+        retries += 1;
+        if (retries >= MAX_RETRIES) {
+          setStage(STAGE_ERROR);
+          setErrorMessage(`transaction confirmation timed out after ${MAX_RETRIES * 1.5}s — check tx ${txHash} manually`);
+          return;
         }
         setTimeout(confirmTx, 1500);
       }

--- a/src/pages/teleport/swap/components/TokenSetterSwap.tsx
+++ b/src/pages/teleport/swap/components/TokenSetterSwap.tsx
@@ -73,7 +73,7 @@ function TokenSetterSwap({
         <InputNumberDecimalScale
           id={id}
           value={tokenAmountValue}
-          onValueChange={(value) => amountChangeHandler(value, id)}
+          onValueChange={(value, event) => { if (event) amountChangeHandler(value, id); }}
           title={`choose amount to ${textAction}`}
           validAmount={validInputAmount}
           validAmountMessage={validAmountMessage}

--- a/src/pages/teleport/swap/swap.tsx
+++ b/src/pages/teleport/swap/swap.tsx
@@ -50,6 +50,8 @@ function Swap() {
   const [isExceeded, setIsExceeded] = useState<boolean>(false);
   const poolPrice = useGetSwapPrice(tokenA, tokenB, tokenAPoolAmount, tokenBPoolAmount);
   const firstEffectOccured = useRef(false);
+  const skipRecalc = useRef(false);
+  const amountChangeHandlerRef = useRef<typeof amountChangeHandler>(null!);
   const [tokenABalance, setTokenABalance] = useState(0);
   const [tokenBBalance, setTokenBBalance] = useState(0);
 
@@ -155,12 +157,20 @@ function Swap() {
   );
 
   useEffect(() => {
+    amountChangeHandlerRef.current = amountChangeHandler;
+  }, [amountChangeHandler]);
+
+  useEffect(() => {
     // update swap price for current amount tokenA
-    if (update || new BigNumber(tokenAAmount).comparedTo(0)) {
-      amountChangeHandler(tokenAAmount, TokenSetterId.tokenAAmount);
+    if (skipRecalc.current) {
+      skipRecalc.current = false;
+      return;
+    }
+    if (Number(tokenAAmount) > 0) {
+      amountChangeHandlerRef.current(tokenAAmount, TokenSetterId.tokenAAmount);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [update, amountChangeHandler, tokenAAmount]);
+  }, [update, tokenAAmount, tokenAPoolAmount, tokenBPoolAmount]);
 
   const validInputAmountTokenA = useMemo(() => {
     const isValid = Number(tokenAAmount) > 0 && !!tokenABalance;
@@ -266,6 +276,10 @@ function Swap() {
   }
 
   const updateFunc = useCallback(() => {
+    skipRecalc.current = true;
+    setTokenAAmount('');
+    setTokenBAmount('');
+    setSwapPrice(0);
     setUpdate((item) => item + 1);
     dataSwapTxs.refetch();
     refreshBalances();
@@ -287,7 +301,6 @@ function Swap() {
 
   useEffect(() => {
     if (firstEffectOccured.current) {
-      // eslint-disable-next-line react-hooks/exhaustive-deps
       const query = {
         from: tokenA,
         to: tokenB,
@@ -307,11 +320,11 @@ function Swap() {
         setTokenB(to);
         if (Number(amount) > 0) {
           setTokenAAmount(amount);
-          amountChangeHandler(amount, TokenSetterId.tokenAAmount);
         }
       }
     }
-  }, [tokenA, tokenB, tokenAAmount, setSearchParams, searchParams, amountChangeHandler]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [tokenA, tokenB, tokenAAmount, setSearchParams]);
 
   const getPercentsOfToken = useCallback(() => {
     return tokenABalance > 0
@@ -375,7 +388,7 @@ function Swap() {
                 <Slippage value={useGetSlippage} />
                 {Number(tokenAAmount) > 0 && (
                   <span style={{ color: 'var(--grayscale-dark)', fontSize: '0.75rem', marginLeft: 8 }}>
-                    fee: <span style={{ color: 'var(--grayscale-primary)' }}>{new BigNumber(tokenAAmount).multipliedBy(0.003).dp(tokenACoinDecimals > 0 ? tokenACoinDecimals : 2).toString()}</span> (0.3%)
+                    fee (0.3%): <span style={{ color: 'var(--grayscale-primary)' }}>{new BigNumber(tokenAAmount).multipliedBy(0.003).dp(tokenACoinDecimals > 0 ? tokenACoinDecimals : 2).toString()}</span>
                   </span>
                 )}
               </>

--- a/src/pages/teleport/swap/swap.tsx
+++ b/src/pages/teleport/swap/swap.tsx
@@ -51,7 +51,7 @@ function Swap() {
   const poolPrice = useGetSwapPrice(tokenA, tokenB, tokenAPoolAmount, tokenBPoolAmount);
   const firstEffectOccured = useRef(false);
   const skipRecalc = useRef(false);
-  const amountChangeHandlerRef = useRef<typeof amountChangeHandler>(null!);
+  const tokenAAmountRef = useRef('');
   const [tokenABalance, setTokenABalance] = useState(0);
   const [tokenBBalance, setTokenBBalance] = useState(0);
 
@@ -145,32 +145,69 @@ function Swap() {
         setSwapPrice(0);
       }
 
+      const counterPairStr = counterPairAmount.toString(10);
       if (isReverse) {
-        setTokenBAmount(inputAmount);
-        setTokenAAmount(counterPairAmount.toString(10));
+        setTokenBAmount(String(inputAmount));
+        setTokenAAmount(counterPairStr);
       } else {
-        setTokenAAmount(inputAmount);
-        setTokenBAmount(counterPairAmount.toString(10));
+        setTokenAAmount(String(inputAmount));
+        setTokenBAmount(counterPairStr);
       }
     },
     [tokenAPoolAmount, tokenB, tokenA, tokenBPoolAmount, tokenACoinDecimals, tokenBCoinDecimals]
   );
 
+  // Recalculate only the output (tokenB + swapPrice) without touching tokenA.
+  // This prevents the feedback loop where setting tokenA triggers InputNumber
+  // re-render → onValueChange → amountChangeHandler → setTokenA → loop.
+  const recalcOutput = useCallback(
+    (inputAmount: string) => {
+      if (tokenAPoolAmount && tokenBPoolAmount && Number(inputAmount) > 0) {
+        const state = {
+          tokenB,
+          tokenA,
+          tokenBPoolAmount,
+          tokenAPoolAmount,
+          coinDecimalsA: tokenACoinDecimals,
+          coinDecimalsB: tokenBCoinDecimals,
+          isReverse: false,
+        };
+
+        const { counterPairAmount, price } = calculatePairAmount(inputAmount, state);
+        setSwapPrice(price.toNumber());
+        setTokenBAmount(counterPairAmount.toString(10));
+      } else {
+        setSwapPrice(0);
+        setTokenBAmount('0');
+      }
+    },
+    [tokenAPoolAmount, tokenB, tokenA, tokenBPoolAmount, tokenACoinDecimals, tokenBCoinDecimals]
+  );
+
+  const recalcOutputRef = useRef<typeof recalcOutput>(null!);
   useEffect(() => {
-    amountChangeHandlerRef.current = amountChangeHandler;
-  }, [amountChangeHandler]);
+    recalcOutputRef.current = recalcOutput;
+  }, [recalcOutput]);
+
+  // Keep tokenAAmountRef in sync
+  useEffect(() => {
+    tokenAAmountRef.current = tokenAAmount;
+  }, [tokenAAmount]);
 
   useEffect(() => {
-    // update swap price for current amount tokenA
+    // Recalculate output when pool data changes or update is triggered.
+    // tokenAAmount is read from ref to avoid being a dependency —
+    // user input already calls amountChangeHandler directly.
     if (skipRecalc.current) {
       skipRecalc.current = false;
       return;
     }
-    if (Number(tokenAAmount) > 0) {
-      amountChangeHandlerRef.current(tokenAAmount, TokenSetterId.tokenAAmount);
+    const amount = tokenAAmountRef.current;
+    if (Number(amount) > 0) {
+      recalcOutputRef.current(amount);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [update, tokenAAmount, tokenAPoolAmount, tokenBPoolAmount]);
+  }, [update, tokenAPoolAmount, tokenBPoolAmount]);
 
   const validInputAmountTokenA = useMemo(() => {
     const isValid = Number(tokenAAmount) > 0 && !!tokenABalance;
@@ -301,30 +338,20 @@ function Swap() {
 
   useEffect(() => {
     if (firstEffectOccured.current) {
-      const query = {
-        from: tokenA,
-        to: tokenB,
-      };
-
-      if (Number(tokenAAmount) > 0) {
-        query.amount = tokenAAmount;
-      }
-
-      setSearchParams(createSearchParams(query), { replace: true });
+      setSearchParams(createSearchParams({ from: tokenA, to: tokenB }), { replace: true });
     } else {
       firstEffectOccured.current = true;
       const param = Object.fromEntries(searchParams.entries());
       if (Object.keys(param).length > 0) {
-        const { from, to, amount } = param;
-        setTokenA(from);
-        setTokenB(to);
-        if (Number(amount) > 0) {
-          setTokenAAmount(amount);
-        }
+        const { from, to } = param;
+        if (from) setTokenA(from);
+        if (to) setTokenB(to);
+        // clean URL: remove stale params like amount
+        setSearchParams(createSearchParams({ from: from || tokenA, to: to || tokenB }), { replace: true });
       }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [tokenA, tokenB, tokenAAmount, setSearchParams]);
+  }, [tokenA, tokenB, setSearchParams]);
 
   const getPercentsOfToken = useCallback(() => {
     return tokenABalance > 0

--- a/src/pages/teleport/swap/swap.tsx
+++ b/src/pages/teleport/swap/swap.tsx
@@ -334,19 +334,18 @@ function Swap() {
     poolPrice,
   };
 
-  const adviserError = useMemo(() => {
+  const adviserText = useMemo(() => {
     if (belowMinAmount) {
       return 'amount too small: minimum 100 base units required by chain';
     }
     if (exceedsMaxOrderRatio) {
       return 'amount exceeds 10% of pool reserves';
     }
-    return undefined;
+    return 'swap tokens';
   }, [belowMinAmount, exceedsMaxOrderRatio]);
 
   useAdviserTexts({
-    defaultText: 'swap tokens',
-    error: adviserError,
+    defaultText: adviserText,
   });
 
   return (
@@ -371,7 +370,16 @@ function Swap() {
             onChange={setPercentageBalanceHook}
             onSwapClick={() => tokenChange()}
             tokenPair={pairPrice}
-            text={<Slippage value={useGetSlippage} />}
+            text={
+              <>
+                <Slippage value={useGetSlippage} />
+                {Number(tokenAAmount) > 0 && (
+                  <span style={{ color: 'var(--grayscale-dark)', fontSize: '0.75rem', marginLeft: 8 }}>
+                    fee: <span style={{ color: 'var(--grayscale-primary)' }}>{new BigNumber(tokenAAmount).multipliedBy(0.003).dp(tokenACoinDecimals > 0 ? tokenACoinDecimals : 2).toString()}</span> (0.3%)
+                  </span>
+                )}
+              </>
+            }
           />
 
           <TokenSetterSwap

--- a/src/pages/teleport/swap/swap.tsx
+++ b/src/pages/teleport/swap/swap.tsx
@@ -192,6 +192,16 @@ function Swap() {
     return 0;
   }, [poolPrice, swapPrice]);
 
+  const CHAIN_MIN_OFFER_AMOUNT = 100; // chain rejects offers below 100 base units
+
+  const belowMinAmount = useMemo(() => {
+    if (!tokenAAmount || Number(tokenAAmount) <= 0) {
+      return false;
+    }
+    const rawAmount = new BigNumber(tokenAAmount).shiftedBy(tokenACoinDecimals);
+    return rawAmount.isLessThan(CHAIN_MIN_OFFER_AMOUNT);
+  }, [tokenAAmount, tokenACoinDecimals]);
+
   const exceedsMaxOrderRatio = useMemo(() => {
     if (!tokenAPoolAmount || !tokenAAmount || !tokenACoinDecimals) {
       return false;
@@ -207,13 +217,13 @@ function Swap() {
 
     const validTokenAmountA = !validInputAmountTokenA && Number(tokenAAmount) > 0;
 
-    // check pool, check slippage 3%, check max order ratio 10%
-    if (poolPrice !== 0 && validTokenAmountA && useGetSlippage < 3 && !exceedsMaxOrderRatio) {
+    // check pool, check slippage 3%, check max order ratio 10%, check min amount
+    if (poolPrice !== 0 && validTokenAmountA && useGetSlippage < 3 && !exceedsMaxOrderRatio && !belowMinAmount) {
       exceeded = false;
     }
 
     setIsExceeded(exceeded);
-  }, [poolPrice, tokenAAmount, validInputAmountTokenA, useGetSlippage, exceedsMaxOrderRatio]);
+  }, [poolPrice, tokenAAmount, validInputAmountTokenA, useGetSlippage, exceedsMaxOrderRatio, belowMinAmount]);
 
   const pairPrice = useMemo(() => {
     const isValid = poolPrice && tokenA && tokenB;
@@ -324,8 +334,19 @@ function Swap() {
     poolPrice,
   };
 
+  const adviserError = useMemo(() => {
+    if (belowMinAmount) {
+      return 'amount too small: minimum 100 base units required by chain';
+    }
+    if (exceedsMaxOrderRatio) {
+      return 'amount exceeds 10% of pool reserves';
+    }
+    return undefined;
+  }, [belowMinAmount, exceedsMaxOrderRatio]);
+
   useAdviserTexts({
     defaultText: 'swap tokens',
+    error: adviserError,
   });
 
   return (


### PR DESCRIPTION
## Summary

- Block swap below chain minimum (100 base units) with adviser warning (#1380)
- Add timeout and error handling to tx confirmation polling (#1381)
- Display swap fee (0.3%) next to slippage indicator
- Reset swap amounts after successful transaction
- Fix amount countdown loop on page reload by removing amount from URL sync

## Commits

1. `abed9454` — validate minimum swap amount, show "amount too small" in adviser + block button
2. `c386c1df` — add 30s timeout to tx polling, show error with tx link on timeout
3. `915b69b7` — display "fee (0.3%): {amount}" next to slippage
4. `bdcd2c8e` — reset amounts to empty after successful swap
5. `b39e3d90` — fix countdown loop: split recalcOutput from amountChangeHandler, remove amount from URL sync

## Test plan

- [x] Enter amount below 100 base units → adviser shows warning, swap button disabled
- [x] Swap tokens successfully → amounts reset to empty
- [x] Fee displayed as "fee (0.3%): amount" with white amount color
- [x] Reload page → fields start empty, URL shows only from/to
- [x] Amount stays stable when typing (no countdown)
- [x] Slippage > 3% blocks swap


Closes #1380, closes #1381

🤖 Generated with [Claude Code](https://claude.com/claude-code)